### PR TITLE
bump the version of requests to allow is_redirect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     namespace_packages=['akamai'],
     packages=find_packages(),
     install_requires = [
-        'requests>=1.2.2'
+        'requests>=2.3.0'
         'pyopenssl',
         'ndg-httpsclient',
         'pyasn1',


### PR DESCRIPTION
since https://github.com/akamai-open/AkamaiOPEN-edgegrid-python/commit/7a40eb8f14bad5c774f7535b1675ce0f3d94b21f#diff-4923d3e520a1eef0f427174d795c6b1eR202 uses the is_redirect property you need at least version 2.3.0