### PR TITLE
Adding support for Python 3

### DIFF
--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -37,9 +37,8 @@ if sys.version_info[0] >= 3:
 else:
     # python2.7
     from urlparse import urlparse, parse_qsl, urlunparse
-
-import urllib3.contrib.pyopenssl
-urllib3.contrib.pyopenssl.inject_into_urllib3()
+    import urllib3.contrib.pyopenssl
+    urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Python 3 wasn't working because of urllib3 and pyopenssl issues, this minor change makes the tests pass with both python2 and python3.

Checked against sample code and I was able to create a new version of the code that works with python3.