### PR TITLE
Fixing the indentation

### DIFF
--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -36,9 +36,9 @@ if sys.version_info[0] >= 3:
     from urllib.parse import urlparse, parse_qsl, urlunparse
 else:
     # python2.7
-    from urlparse import urlparse, parse_qsl, urlunparse
-    import urllib3.contrib.pyopenssl
-    urllib3.contrib.pyopenssl.inject_into_urllib3()
+	from urlparse import urlparse, parse_qsl, urlunparse
+	import urllib3.contrib.pyopenssl
+	urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name='edgegrid-python', 
-    version='1.0.9', 
+    version='1.0.10', 
     description='{OPEN} client authentication protocol for python-requests',
     author='Jonathan Landis',
     author_email='jlandis@akamai.com',


### PR DESCRIPTION
For some reason the pip version had spaces showing up for these lines:

+       import urllib3.contrib.pyopenssl
+       urllib3.contrib.pyopenssl.inject_into_urllib3()

I re-indented the lines and they should work correctly now.  Passes with python3 and python2.